### PR TITLE
fix(ci): improve release notes Development section

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -106,13 +106,10 @@ jobs:
 
         ### Development
 
-        \`\`\`bash
-        npm install
-        npm run build
-        sudo cp -r packagemanager /usr/share/cockpit/
-        \`\`\`
-
-        Access at https://localhost:9090 after installing Cockpit.
+        For development setup and build commands, see:
+        - [README.md](https://github.com/hatlabs/cockpit-package-manager/blob/main/README.md) - Installation and usage
+        - [CLAUDE.md](https://github.com/hatlabs/cockpit-package-manager/blob/main/CLAUDE.md) - Development guide
+        - \`./run help\` - Available build and development commands
         EOF
 
         # Create the release (source code is automatically attached by GitHub)


### PR DESCRIPTION
## Changes

Improves the Development section in draft release notes to be more accurate and maintainable.

### Before
```markdown
### Development

\`\`\`bash
npm install
npm run build
sudo cp -r packagemanager /usr/share/cockpit/
\`\`\`

Access at https://localhost:9090 after installing Cockpit.
```

### After
```markdown
### Development

For development setup and build commands, see:
- [README.md](https://github.com/hatlabs/cockpit-package-manager/blob/main/README.md) - Installation and usage
- [CLAUDE.md](https://github.com/hatlabs/cockpit-package-manager/blob/main/CLAUDE.md) - Development guide
- \`./run help\` - Available build and development commands
```

### Rationale

The previous hardcoded instructions were:
1. **Misleading** - Didn't mention the new `./run` script added in v0.1.1
2. **Incomplete** - Omitted TypeScript build setup and testing
3. **Duplicative** - Information already exists in README.md and CLAUDE.md
4. **Unmaintainable** - Would need manual updates whenever build process changes

The new approach references the canonical documentation sources.